### PR TITLE
all: add code implementation for pragmyzer

### DIFF
--- a/cmd/pragmyzer/main.go
+++ b/cmd/pragmyzer/main.go
@@ -1,0 +1,25 @@
+// Copyright 2022 Orijtech, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"github.com/orijtech/pragmyzer"
+)
+
+func main() {
+	singlechecker.Main(pragmyzer.Analyzer)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/orijtech/pragmyzer
+
+go 1.18
+
+require golang.org/x/tools v0.1.9
+
+require (
+	golang.org/x/mod v0.5.1 // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
+golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.1.9 h1:j9KsMiaP1c3B0OTQGth0/k+miLGTgLsAFUCrF2vLcF8=
+golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pragmyzer.go
+++ b/pragmyzer.go
@@ -1,0 +1,87 @@
+// Copyright 2022 Orijtech, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pragmyzer
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const doc = `pragmyzer reports issues with Go pragma directives such as:
+// go:embed file.txt
+var data string
+
+which is invalid and will silently be treated as a comment.
+`
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "pragmyzer",
+	Doc:      doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+}
+
+func imports(pkg *types.Package, target string) bool {
+	for _, imp := range pkg.Imports() {
+		if imp.Path() == target {
+			return true
+		}
+	}
+	return false
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	if !imports(pass.Pkg, "embed") {
+		return nil, nil
+	}
+
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.File)(nil),
+	}
+
+	fset := pass.Fset
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		// 1. Reject anything that doesn't import "_ embed"
+		// Look for the last comment before the variable and see if it has go:embed
+		// Find the comments for each node.
+		f := n.(*ast.File)
+		cmap := ast.NewCommentMap(fset, f, f.Comments)
+		// Our target is to go looking for all comments.
+		// Search for all variables.
+		for _, cgL := range cmap {
+			for _, cg := range cgL {
+				for _, comment := range cg.List {
+					if !strings.HasPrefix(comment.Text, " ") {
+						continue
+					}
+
+					trimmed := strings.TrimSpace(comment.Text)
+					if !strings.HasPrefix(trimmed, "go:") {
+						continue
+					}
+					pass.ReportRangef(comment, "pragmas should NOT have a space")
+				}
+			}
+		}
+	})
+
+	return nil, nil
+}

--- a/pragmyzer_test.go
+++ b/pragmyzer_test.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Orijtech, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pragmyzer
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer, "a")
+}

--- a/testdata/src/a/p.go
+++ b/testdata/src/a/p.go
@@ -1,0 +1,24 @@
+// Copyright 2022 Orijtech, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p
+
+import _ "embed"
+
+// go:embed hello.txt
+var file string
+
+func main() {
+    println(file)
+}

--- a/testdata/src/a/p_test.go
+++ b/testdata/src/a/p_test.go
@@ -1,0 +1,15 @@
+// Copyright 2022 Orijtech, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p


### PR DESCRIPTION
Driven by our own colleagues who accidentally typed

```go
// go:embed file
var file string
```

instead of

```go
//go:embed file
var file string
```

and we didn't catch it during code review yet this caused
a hard to debug bug in production. pragmyzer is meant to flag
insidious bugs like these.